### PR TITLE
#58 STEP1で分析履歴のある選択肢を取得

### DIFF
--- a/app/controllers/api/alternatives_controller.rb
+++ b/app/controllers/api/alternatives_controller.rb
@@ -1,19 +1,12 @@
 class Api::AlternativesController < ApplicationController
   before_action :authenticate!
 
-  def create
-    alternatives = @current_user.alternatives.build(alternative_params)
-
-    if alternatives.save
-      render json: alternatives
-    else
-      render json: alternatives.errors.full_messages, status: :unprocessable_entity
+  def index
+    analyses = @@current_user.analyses
+    alternatives = []
+    analyses.each do |a|
+      alternatives.concat(a.alternative_results.pluck(:name))
     end
-  end
-
-  private
-
-  def alternative_params
-    params.require(:alternative).permit(name: [])
+    render json: alternatives
   end
 end

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -69,4 +69,7 @@ export default {
 #app a {
   text-decoration: none;
 }
+#app .v-btn {
+  text-transform: none;
+}
 </style>

--- a/app/javascript/components/TheHeader.vue
+++ b/app/javascript/components/TheHeader.vue
@@ -98,8 +98,6 @@ export default {
 
 <style scoped>
 #logo {
-  font-family: Avenir;
-  text-transform: none;
   font-size: 18px;
 }
 #logo span {

--- a/app/javascript/pages/analysis/AlternativeInput.vue
+++ b/app/javascript/pages/analysis/AlternativeInput.vue
@@ -7,11 +7,28 @@
         class="mx-auto alternative-forms"
       >
         <h3>STEP1 選択肢の記入</h3>
-        <v-col align="center">
-          <p>
-            あなたが今考えている会社名や求人などを記入してください。
-          </p>
-        </v-col>
+        <v-row>
+          <v-col align="center">
+            <p>
+              あなたが今考えている会社名や求人などを記入してください。
+            </p>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col
+            class="mb-6"
+          >
+            <v-btn
+              v-for="(item, index) in alternativeHistory"
+              @click="pickUpFromHistory(item)"
+              flat
+              outlined
+              color="#6495ed"
+              height="24"
+              class="mr-1"
+            >{{ item }}</v-btn>
+          </v-col>
+        </v-row>
         <div
           v-for="(item, index) in alternatives"
           :key="index"
@@ -61,11 +78,13 @@ export default {
   data() {
     return {
       alternatives: [null, null, null], //要素の数だけフォームが表示される
-      errors: null
+      errors: null,
+      alternativeHistory: null
     }
   },
   computed: {
-    ...mapGetters('analyses', ['getAlternatives'])
+    ...mapGetters('analyses', ['getAlternatives']),
+    ...mapGetters('users', ['getLoginUser'])
   },
   created() {
     // 次ページから戻ってきたときに入力値が残ってるように
@@ -76,6 +95,15 @@ export default {
     this.$watch('alternatives', function() {
       this.setAlternativeEvaluations({eval: null, raw: null})
     })
+    // 分析履歴のある選択肢を取得
+    if (this.getLoginUser) {
+      this.$axios.get('alternatives')
+      .then(res => {
+        this.alternativeHistory = new Set(res.data)
+        console.log(res)
+      })
+      .catch(err => { console.log(err) })
+    }
   },
   methods: {
     addForm() {
@@ -88,6 +116,9 @@ export default {
     },
     isEnough(arr) {
       return arr.length >= 2 ? true : false
+    },
+    pickUpFromHistory(item) {
+      this.alternatives.unshift(item)
     },
     handleAlternative() {
       // バリデーションした上で入力値をストアに保存

--- a/app/javascript/pages/analysis/AlternativeInput.vue
+++ b/app/javascript/pages/analysis/AlternativeInput.vue
@@ -21,7 +21,6 @@
             <v-btn
               v-for="(item, index) in alternativeHistory"
               @click="pickUpFromHistory(item)"
-              flat
               outlined
               color="#6495ed"
               height="24"
@@ -29,11 +28,10 @@
             >{{ item }}</v-btn>
           </v-col>
         </v-row>
-        <div
-          v-for="(item, index) in alternatives"
-          :key="index"
-        >
+        <div>
           <input
+            v-for="(item, index) in alternatives"
+            :key="index"
             :id="'alternative' + index"
             v-model="alternatives[index]"
             class="form-control mb-3"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   namespace :api, format: 'json' do
     post 'login', to: 'sessions#create'
+    get 'alternatives', to: 'alternatives#index'
     resources :users, only: :create do
       collection do
         get 'me'


### PR DESCRIPTION
# Issue
#58 
# 概要
STEP1で分析履歴のある選択肢を取得
- ログイン状態の時STEP1ページのcreateフックでalternative#indexにリクエスト
- 分析履歴のある選択肢を取得し重複を覗いた上で各々をボタンとして表示
- ボタンを押すとそれに対応する選択肢名がalternativesの配列の先頭に追加され、記入欄に記入された形になる
